### PR TITLE
feat: make scripts configurable through use of env variables

### DIFF
--- a/play/scripts/create-instance.sh
+++ b/play/scripts/create-instance.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 
-TMP_DIR="/ebs1/tmp"
-INSTANCE_DIR="/ebs1/instances"
+# INIT
+. env.sh
+
+# GLOBALS
+# ---
+# TMP_DIR
+# BASE_DIR
+
+
 INSTANCE_FILE="dhis-instance"
 INSTANCE_URL="https://s3-eu-west-1.amazonaws.com/content.dhis2.org/lib/${INSTANCE_FILE}.tar.gz"
 
@@ -11,7 +18,7 @@ if [ $# -le 1 ]; then
 fi
 
 function validate() {
-  if [ -d $INSTANCE_DIR/$1 ]; then
+  if [ -d "${BASE_DIR}/${1}" ]; then
     echo "Instance $1 already exists."
     exit 1
   fi
@@ -36,22 +43,22 @@ function create() {
   wget --progress=bar $INSTANCE_URL -O ${TMP_DIR}/${INSTANCE_FILE}.tar.gz
 
   echo "Extracting instance archive"
-  tar -zxf ${TMP_DIR}/${INSTANCE_FILE}.tar.gz -C $INSTANCE_DIR
+  tar -zxf "${TMP_DIR}/${INSTANCE_FILE}.tar.gz" -C "$BASE_DIR"
 
   echo "Renaming instance"
-  mv $INSTANCE_DIR/$INSTANCE_FILE $INSTANCE_DIR/$1
+  mv "${BASE_DIR}/${INSTANCE_FILE}" "${BASE_DIR}/${1}"
 
   echo "Configuring Tomcat"
-  echo "export DHIS2_HOME='${INSTANCE_DIR}/$1/home'" >> $INSTANCE_DIR/$1/tomcat/bin/setclasspath.sh
-  echo "export JAVA_HOME='/usr/lib/jvm/java-8-oracle/'" >> $INSTANCE_DIR/$1/tomcat/bin/setclasspath.sh
-  echo "export JAVA_OPTS='-Xmx1500m -Xms1000m'" >> $INSTANCE_DIR/$1/tomcat/bin/setclasspath.sh
-  sed -i "s/Server port=\"8005\" shutdown=\"SHUTDOWN\"/Server port=\"${SHUTDOWN_PORT}\" shutdown=\"SHUTDOWN\"/g" $INSTANCE_DIR/$1/tomcat/conf/server.xml
-  sed -i "s/Connector protocol=\"HTTP\/1.1\" port=\"8080\"/Connector protocol=\"HTTP\/1.1\" port=\"${PORT}\"/g" $INSTANCE_DIR/$1/tomcat/conf/server.xml
+  echo "export DHIS2_HOME='${BASE_DIR}/${1}/home'" >> "${BASE_DIR}/${1}/tomcat/bin/setclasspath.sh"
+  echo "export JAVA_HOME='/usr/lib/jvm/java-8-oracle/'" >> "${BASE_DIR}/${1}/tomcat/bin/setclasspath.sh"
+  echo "export JAVA_OPTS='-Xmx1500m -Xms1000m'" >> "${BASE_DIR}/${1}/tomcat/bin/setclasspath.sh"
+  sed -i "s/Server port=\"8005\" shutdown=\"SHUTDOWN\"/Server port=\"${SHUTDOWN_PORT}\" shutdown=\"SHUTDOWN\"/g" "${BASE_DIR}/${1}/tomcat/conf/server.xml"
+  sed -i "s/Connector protocol=\"HTTP\/1.1\" port=\"8080\"/Connector protocol=\"HTTP\/1.1\" port=\"${PORT}\"/g" "${BASE_DIR}/${1}/tomcat/conf/server.xml"
 
   echo "Configuring DHIS 2"
-  echo "connection.url = jdbc:postgresql:$1" >> $INSTANCE_DIR/$1/home/dhis.conf
-  echo "connection.username = dhis" >> $INSTANCE_DIR/$1/home/dhis.conf
-  echo "connection.password = dhis" >> $INSTANCE_DIR/$1/home/dhis.conf
+  echo "connection.url = jdbc:postgresql:${1}" >> "${BASE_DIR}/${1}/home/dhis.conf"
+  echo "connection.username = dhis" >> "${BASE_DIR}/${1}/home/dhis.conf"
+  echo "connection.password = dhis" >> "${BASE_DIR}/${1}/home/dhis.conf"
 }
 
 validate $1 $2

--- a/play/scripts/env.sh
+++ b/play/scripts/env.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+if [[ ! -n ${TMP_DIR:-} ]]; then
+    export TMP_DIR="/ebs1/tmp"
+fi
+
+if [[ ! -n ${BASE_DIR:-} ]]; then
+    export BASE_DIR="/ebs1/instances"
+fi
+
+if [[ ! -n ${BASE_URL:-} ]]; then
+    export BASE_URL="https://play.dhis2.org"
+fi
+
+if [[ ! -n ${DB_BASE_DIR:-} ]]; then
+    export DB_BASE_DIR="/ebs1/databases/sierra-leone"
+fi
+
+if [[ ! -n ${DB_FILE:-} ]]; then
+    export DB_FILE="dhis2-db-sierra-leone"
+fi
+
+if [[ ! -n ${AUTH:-} ]]; then
+    export AUTH="system:System123"
+fi
+
+if [[ ! -n ${JENKINS_WORKSPACE:-} ]]; then
+    export JENKINS_WORKSPACE="/ebs1/jenkins/workspace"
+fi
+
+if [[ ! -n ${WAR_LOCATION:-} ]]; then
+    export WAR_LOCATION="${JENKINS_WORKSPACE}/dhis2-${1}/dhis-2/dhis-web/dhis-web-portal/target/dhis.war"
+fi
+
+if [[ ! -n ${S3_LOCATION:-} ]]; then
+    export S3_LOCATION="s3://releases.dhis2.org/${1}/dhis.war"
+fi

--- a/play/scripts/log-instance.sh
+++ b/play/scripts/log-instance.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
-INSTANCE_BASE_DIR="/ebs1/instances"
+# INIT
+. env.sh
+
+# GLOBALS
+# ---
+# BASE_DIR
 
 if [ $# -eq 0 ]; then
   echo -e "Usage: $0 <instances...>\n"
   exit 1
 fi
 
-tail -f $INSTANCE_BASE_DIR/$1/tomcat/logs/catalina.out -n 1000
+tail -f "${BASE_DIR}/${1}/tomcat/logs/catalina.out" -n 1000

--- a/play/scripts/reinit-db-instance.sh
+++ b/play/scripts/reinit-db-instance.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
-TMP_DIR="/ebs1/tmp"
-DB_BASE_DIR="/ebs1/databases/sierra-leone"
-DB_FILE="dhis2-db-sierra-leone"
-INSTANCE_BASE_URL="https://play.dhis2.org"
-AUTH="system:System123"
+# INIT
+. env.sh
+
+# GLOBALS
+# ---
+# TMP_DIR
+# BASE_URL
+# DB_BASE_DIR
+# DB_FILE
+# AUTH
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -14,7 +19,7 @@ if [ $# -eq 0 ]; then
 fi
 
 function validate() {
-  if [ ! -d $DB_BASE_DIR/$1 ]; then
+  if [ ! -d "${DB_BASE_DIR}/${1}" ]; then
     echo "Instance $1 does not have the required SQL file database directory."
     exit 1
   fi
@@ -26,15 +31,15 @@ function run() {
   sudo -u postgres dropdb $1
   sudo -u postgres createdb -O dhis $1
 
-  cp $DB_BASE_DIR/$1/$DB_FILE.sql.gz ${TMP_DIR}/$DB_FILE-$1.sql.gz
-  gunzip -f ${TMP_DIR}/$DB_FILE-$1.sql.gz
-  psql -d $1 -U dhis -f ${TMP_DIR}/$DB_FILE-$1.sql
+  cp "${DB_BASE_DIR}/${1}/${DB_FILE}.sql.gz "${TMP_DIR}/${DB_FILE}-${1}.sql.gz"
+  gunzip -f "${TMP_DIR}/${DB_FILE}-${1}.sql.gz"
+  sudo -u postgres psql -d "${1}" -f "${TMP_DIR}/${DB_FILE}-${1}.sql"
   sleep 2
   $DIR/start-instance.sh $1
 }
 
 function analytics() {
-  curl ${INSTANCE_BASE_URL}/$1/api/resourceTables/analytics -X POST -u $AUTH
+  curl "${BASE_URL}/${1}/api/resourceTables/analytics" -X POST -u "${AUTH}"
 }
 
 for instance in $@; do

--- a/play/scripts/reinit-db-instance.sh
+++ b/play/scripts/reinit-db-instance.sh
@@ -31,7 +31,7 @@ function run() {
   sudo -u postgres dropdb $1
   sudo -u postgres createdb -O dhis $1
 
-  cp "${DB_BASE_DIR}/${1}/${DB_FILE}.sql.gz "${TMP_DIR}/${DB_FILE}-${1}.sql.gz"
+  cp "${DB_BASE_DIR}/${1}/${DB_FILE}.sql.gz" "${TMP_DIR}/${DB_FILE}-${1}.sql.gz"
   gunzip -f "${TMP_DIR}/${DB_FILE}-${1}.sql.gz"
   sudo -u postgres psql -d "${1}" -f "${TMP_DIR}/${DB_FILE}-${1}.sql"
   sleep 2

--- a/play/scripts/reinit-instance.sh
+++ b/play/scripts/reinit-instance.sh
@@ -26,8 +26,7 @@ function cleanWebApps() {
 }
 
 function downloadWar() {
-  wget --progress=bar
-  "https://s3-eu-west-1.amazonaws.com/releases.dhis2.org/${1}/dhis.war" -O "${BASE_DIR}/${1}/tomcat/webapps/${1}.war"
+  wget --progress=bar "https://s3-eu-west-1.amazonaws.com/releases.dhis2.org/${1}/dhis.war" -O "${BASE_DIR}/${1}/tomcat/webapps/${1}.war"
 }
 
 for instance in $@; do

--- a/play/scripts/reinit-instance.sh
+++ b/play/scripts/reinit-instance.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# INIT
+. env.sh
+
+# GLOBALS
+# ---
+# BASE_DIR
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [ $# -eq 0 ]; then
@@ -8,18 +15,19 @@ if [ $# -eq 0 ]; then
 fi
 
 function validate() {
-  if [ ! -d /ebs1/instances/$1 ]; then
+  if [ ! -d "${BASE_DIR}/${1}" ]; then
     echo "Instance $1 does not exist."
     exit 1
   fi
 }
 
 function cleanWebApps() {
-  sudo rm -rf /ebs1/instances/$1/tomcat/webapps/*
+  sudo rm -rf "${BASE_DIR}/${1}/tomcat/webapps/*"
 }
 
 function downloadWar() {
-  wget --progress=bar https://s3-eu-west-1.amazonaws.com/releases.dhis2.org/$1/dhis.war -O /ebs1/instances/$1/tomcat/webapps/$1.war
+  wget --progress=bar
+  "https://s3-eu-west-1.amazonaws.com/releases.dhis2.org/${1}/dhis.war" -O "${BASE_DIR}/${1}/tomcat/webapps/${1}.war"
 }
 
 for instance in $@; do

--- a/play/scripts/restart-instance.sh
+++ b/play/scripts/restart-instance.sh
@@ -1,10 +1,34 @@
 #!/bin/bash
 
+# INIT
+. env.sh
+
+# GLOBALS
+# ---
+# BASE_DIR
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 if [ $# -eq 0 ]; then
   echo -e "Usage: $0 <instances...>\n"
   exit 1
 fi
 
-./stop-instance.sh $@
-sleep 5
-./start-instance.sh $@
+function validate() {
+  if [ ! -d "${BASE_DIR}/${1}" ]; then
+    echo "Instance $1 does not exist."
+    exit 1
+  fi
+}
+
+function run() {
+  local t=$1
+  $DIR/stop-instance.sh "$t"
+  sleep 5
+  $DIR/start-instance.sh "$t"
+}
+
+for instance in $@; do
+  validate $instance
+  run $instance
+done

--- a/play/scripts/restore-db.sh
+++ b/play/scripts/restore-db.sh
@@ -1,14 +1,20 @@
 #!/bin/bash
 
+# INIT
+. env.sh
+
+# GLOBALS
+# ---
+# TMP_DIR
+# BASE_URL
+# DB_BASE_DIR
+# DB_FILE
+# AUTH
+
 # Requires that the demo database GitHub repository is cloned locally.
 # Requires that a 'dhis' database user which can create databases exists.
-# The 'TMP_DIR' and 'DB_BASE_DIR' variables can be adjusted to match the local env.
-# Sample usage: $ ./restore-db.sh dev
 
-TMP_DIR="/ebs1/tmp"
-DB_BASE_DIR="/ebs1/databases/sierra-leone"
-DB_FILE="dhis2-db-sierra-leone"
-AUTH="system:System123"
+# Sample usage: $ ./restore-db.sh dev
 
 if [ $# -eq 0 ]; then
   echo -e "Usage: $0 <instances...>\n"
@@ -16,7 +22,7 @@ if [ $# -eq 0 ]; then
 fi
 
 function validate() {
-  if [ ! -d $DB_BASE_DIR/$1 ]; then
+  if [ ! -d "${DB_BASE_DIR}/${1}" ]; then
     echo "Instance $1 does not have the required SQL file database directory."
     exit 1
   fi
@@ -25,13 +31,13 @@ function validate() {
 function run() {
   echo "Restoring database: $1"
   
-  sudo -u postgres dropdb $1
-  sudo -u postgres createdb -O dhis $1
+  sudo -u postgres dropdb "$1"
+  sudo -u postgres createdb -O dhis "$1"
   echo "Dropped and created db: $1"
 
-  cp $DB_BASE_DIR/$1/$DB_FILE.sql.gz ${TMP_DIR}/$DB_FILE-$1.sql.gz
-  gunzip -f ${TMP_DIR}/$DB_FILE-$1.sql.gz
-  psql -d $1 -U dhis -f ${TMP_DIR}/$DB_FILE-$1.sql
+  cp "${DB_BASE_DIR}/${1}/${DB_FILE}.sql.gz" "${TMP_DIR}/${DB_FILE}-${1}.sql.gz"
+  gunzip -f "${TMP_DIR}/${DB_FILE}-${1}.sql.gz"
+  psql -d "$1" -U dhis -f "${TMP_DIR}/${DB_FILE}-${1}.sql"
   echo "Restored database: $1"
 }
 

--- a/play/scripts/start-instance.sh
+++ b/play/scripts/start-instance.sh
@@ -1,19 +1,26 @@
 #!/bin/bash
 
+# INIT
+. env.sh
+
+# GLOBALS
+# ---
+# BASE_DIR
+
 if [ $# -eq 0 ]; then
   echo -e "Usage: $0 <instances...>\n"
   exit 1
 fi
 
 function validate() {
-  if [ ! -d /ebs1/instances/$1 ]; then
+  if [ ! -d "${BASE_DIR}/${1}" ]; then
     echo "Instance $1 does not exist."
     exit 1
   fi
 }
 
 function run() {
-  CATALINA_PID="/var/run/tomcat/$1.pid" /ebs1/instances/$1/tomcat/bin/startup.sh
+  CATALINA_PID="/var/run/tomcat/${1}.pid" "${BASE_DIR}/${1}/tomcat/bin/startup.sh"
 }
 
 for instance in $@; do

--- a/play/scripts/stop-instance.sh
+++ b/play/scripts/stop-instance.sh
@@ -1,22 +1,29 @@
 #!/bin/bash
 
+# INIT
+. env.sh
+
+# GLOBALS
+# ---
+# BASE_DIR
+
 if [ $# -eq 0 ]; then
   echo -e "Usage: $0 <instances...>\n"
   exit 1
 fi
 
 function validate() {
-  if [ ! -d /ebs1/instances/$1 ]; then
+  if [ ! -d "${BASE_DIR}/${1}" ]; then
     echo "Instance $1 does not exist."
     exit 1
   fi
 }
 
 function run() {
-  CATALINA_PID="/var/run/tomcat/$1.pid" /ebs1/instances/$1/tomcat/bin/shutdown.sh
+  CATALINA_PID="/var/run/tomcat/${1}.pid" "${BASE_DIR}/${1}/tomcat/bin/shutdown.sh"
   sleep 2
 
-  if [ -a /var/run/tomcat/$1.pid ]; then
+  if [ -a "/var/run/tomcat/${1}.pid" ]; then
     echo "Tomcat is still running, doing manual kill"
     kill -9 `cat /var/run/tomcat/$1.pid`
   fi

--- a/play/scripts/sync-db-s3.sh
+++ b/play/scripts/sync-db-s3.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
-DB_DIR="/ebs1/databases"
+# INIT
+. env.sh
 
-CUR_DIR=$(pwd)
+# GLOBALS
+# ---
+# DB_DIR
 
 # Move to db directory
-cd $DB_DIR
+pushd $DB_DIR
 
 # Pull latest updates
 git pull --ff-only --all
@@ -14,5 +17,4 @@ git pull --ff-only --all
 aws s3 sync . s3://databases.dhis2.org
 
 # Move back to original directory
-cd $CUR_DIR
-
+popd

--- a/play/scripts/sync-war-s3.sh
+++ b/play/scripts/sync-war-s3.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
-WAR_LOCATION="/ebs1/jenkins/workspace/dhis2-$1/dhis-2/dhis-web/dhis-web-portal/target/dhis.war"
-S3_LOCATION="s3://releases.dhis2.org/$1/dhis.war"
+# INIT
+. env.sh
 
-if [ ! -d /ebs1/jenkins/workspace/dhis2-$1 ]; then
+# GLOBALS
+# ---
+# WAR_LOCATION
+# S3_LOCATION
+# JENKINS_WORKSPACE
+
+if [ ! -d "${JENKINS_WORKSPACE}/dhis2-$1 ]; then
   echo "No job with name dhis2-$1 exists."
   exit 1
 fi


### PR DESCRIPTION
Using an `env.sh` file (for the Play-server defaults) we can keep track of all the global variables used throughout the scripts and make it configurable using a local environment file for other servers.

So on my server I use the following `server-env` file which I source from `.bashrc`:

```
#!/bin/bash

export BASE_URL="https://dhis2.vardevs.se"

export TMP_DIR="/opt/dhis2/tmp"
export BASE_DIR="/opt/dhis2/instances"
export DB_BASE_DIR="/opt/dhis2/databases/sierra-leone"

export AUTH="system:System123"
export DB_FILE="dhis2-db-sierra-leone"
```

I let `JENKINS_WORKSPACE`, `S3_LOCATION`, and `WAR_LOCATION` fallback to whatever their respective defaults are. Since the `env.sh` script is sourced from inside each script, the subprocess has access to the parameters passed to the script as `$1` etc. It's just something to mentally keep track off when reading the `env.sh` file.

Since these scripts are in use today I have done the minimal amount of changes I need. Further testing is required. :)