### PR TITLE
feat: Add script for deleting old WARs [DEVOPS-188]

### DIFF
--- a/ci/scripts/delete-old-wars.sh
+++ b/ci/scripts/delete-old-wars.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+version="$1"
+
+type="canary"
+
+prefix="$version/$type"
+
+bucket="releases.dhis2.org"
+
+versions_json="https://releases.dhis2.org/v1/versions/stable.json"
+
+
+latest_patch=$(
+  curl -fsSL "$versions_json" |
+  jq -r --arg version "$version" '.versions[] | select(.name == $version ) | .latestPatchVersion'
+)
+
+last_supported_patch=$(($latest_patch - 2))
+
+last_supported_date=$(
+  curl -fsSL "$versions_json" |
+  jq -r --arg version "$version" --arg patch "$last_supported_patch" '.versions[] | select(.name == $version) | .patchVersions[] | select(.version == ($patch|tonumber)) | .releaseDate'
+)
+
+aws s3api list-object-versions --bucket "$bucket" --prefix "$prefix" --max-items=3 --query 'Versions[?LastModified < `'$last_supported_date'`]' | jq '{Objects: [ .[] | {Key: .Key, VersionId: .VersionId} ] }' > old-wars.json
+
+aws s3api delete-objects --bucket "$bucket" --delete file://old-wars.json

--- a/ci/scripts/delete-old-wars.sh
+++ b/ci/scripts/delete-old-wars.sh
@@ -35,7 +35,6 @@ fi
 aws s3api list-object-versions \
   --bucket "$bucket" \
   --prefix "$prefix" \
-  --max-items=3 \
   --query "Versions[?LastModified < \`$last_supported_date\`]" |
 jq '{Objects: [.[] | {Key: .Key, VersionId: .VersionId}]}' > old-wars.json
 

--- a/ci/scripts/delete-old-wars.sh
+++ b/ci/scripts/delete-old-wars.sh
@@ -15,16 +15,28 @@ versions_json="https://releases.dhis2.org/v1/versions/stable.json"
 
 latest_patch=$(
   curl -fsSL "$versions_json" |
-  jq -r --arg version "$version" '.versions[] | select(.name == $version ) | .latestPatchVersion'
+  jq -r --arg version "$version" \
+    '.versions[] | select(.name == $version ) | .latestPatchVersion'
 )
 
 last_supported_patch=$(($latest_patch - 2))
 
 last_supported_date=$(
   curl -fsSL "$versions_json" |
-  jq -r --arg version "$version" --arg patch "$last_supported_patch" '.versions[] | select(.name == $version) | .patchVersions[] | select(.version == ($patch|tonumber)) | .releaseDate'
+  jq -r --arg version "$version" \
+    --arg patch "$last_supported_patch" \
+    '.versions[] | select(.name == $version) | .patchVersions[] | select(.version == ($patch|tonumber)) | .releaseDate'
 )
 
 aws s3api list-object-versions --bucket "$bucket" --prefix "$prefix" --max-items=3 --query 'Versions[?LastModified < `'$last_supported_date'`]' | jq '{Objects: [ .[] | {Key: .Key, VersionId: .VersionId} ] }' > old-wars.json
 
-aws s3api delete-objects --bucket "$bucket" --delete file://old-wars.json
+aws s3api list-object-versions \
+  --bucket "$bucket" \
+  --prefix "$prefix" \
+  --max-items=3 \
+  --query 'Versions[?LastModified < `'$last_supported_date'`]' |
+  jq '{Objects: [ .[] | {Key: .Key, VersionId: .VersionId} ] }' > old-wars.json
+
+aws s3api delete-objects \
+  --bucket "$bucket" \
+  --delete file://old-wars.json

--- a/ci/scripts/delete-old-wars.sh
+++ b/ci/scripts/delete-old-wars.sh
@@ -38,6 +38,13 @@ aws s3api list-object-versions \
   --query "Versions[?LastModified < \`$last_supported_date\`]" |
 jq '{Objects: [.[] | {Key: .Key, VersionId: .VersionId}]}' > old-wars.json
 
-aws s3api delete-objects \
-  --bucket "$bucket" \
-  --delete file://old-wars.json
+number_of_objects=$(jq -r '.Objects | length' old-wars.json)
+
+if [[ "$number_of_objects" -gt 0 ]]; then
+  echo "Deleting $number_of_objects objects ..."
+  aws s3api delete-objects \
+    --bucket "$bucket" \
+    --delete file://old-wars.json
+else
+  echo "Nothing to delete."
+fi

--- a/ci/scripts/delete-old-wars.sh
+++ b/ci/scripts/delete-old-wars.sh
@@ -29,7 +29,7 @@ last_supported_date=$(
 )
 
 if [[ "$version" == "master" ]]; then
-  last_supported_date=$(date -d "-1 week" +%Y-%m-%d)
+  last_supported_date=$(date -d "-1 month" +%Y-%m-%d)
 fi
 
 aws s3api list-object-versions \


### PR DESCRIPTION
Deletes old canary WARs from the releases.dhis2.org bucket, where old means anything before the release date of `the latest patch number - 2`.

Example run:
```
./ci/scripts/delete-old-wars.sh 2.34

{
    "Deleted": [
        {
            "Key": "2.34/canary/dhis2-canary-2.34-2020-03-11.war",
            "VersionId": "YDRV9bpYdKb7.XO_MsfLcvqbfYg64pb."
        },
        {
            "Key": "2.34/canary/dhis2-canary-2.34-2020-03-14.war",
            "VersionId": "Lo_cHbe.mWaIzLpGaofNnch6CCxbrmGM"
        },
        {
            "Key": "2.34/canary/dhis2-canary-2.34-2020-03-13.war",
            "VersionId": "jE5qatLPXRjFlVXCrfuX2QzpsZJvlXx5"
        }
    ]
}
```