### PR TITLE
fix: Only get the latest patch version if there's a hotfix

### DIFF
--- a/ci/scripts/delete-old-wars.sh
+++ b/ci/scripts/delete-old-wars.sh
@@ -25,7 +25,7 @@ last_supported_date=$(
   curl -fsSL "$versions_json" |
   jq -r --arg version "$version" \
     --arg patch "$last_supported_patch" \
-    '.versions[] | select(.name == $version) | .patchVersions[] | select(.version == ($patch|tonumber)) | .releaseDate'
+    'last(.versions[] | select(.name == $version) | .patchVersions[] | select(.version == ($patch|tonumber)) | .releaseDate)'
 )
 
 if [[ "$version" == "master" ]]; then


### PR DESCRIPTION
If there's a hotfix for a given patch version, like `2.36.10` and `2.36.10.1`,  the jq filter will find both of them and output multiple dates, which breaks the script. Wrapping the jq filter in the `last()` function ensures we only get the latest hotfix version in such cases.