### PR TITLE
ci: exit with non-zero code when there are errors with deleting old wars

### DIFF
--- a/ci/scripts/delete-old-wars.sh
+++ b/ci/scripts/delete-old-wars.sh
@@ -44,7 +44,8 @@ if [[ "$number_of_objects" -gt 0 ]]; then
   echo "Deleting $number_of_objects objects ..."
   aws s3api delete-objects \
     --bucket "$bucket" \
-    --delete file://old-wars.json
+    --delete file://old-wars.json |
+  jq -e 'has("Errors") | not' # exit with non-zero code when there are "Errors" in the response
 else
   echo "Nothing to delete."
 fi


### PR DESCRIPTION
Deleting old canary wars has been failing for some time without being noticed. Adding a check for `Errors` key in the response with `jq`, in order to fail the stage with a non-zero code when it exists.